### PR TITLE
fix: use hyphenated name in SKILL.md

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Vibe Security Skill
+name: Vibe-Security-Skill
 description: This skill helps Claude write secure web applications. Use when working on any web application to ensure security best practices are followed.
 ---
 


### PR DESCRIPTION
Changed name: vibe security skill → name: vibe-security-skill 
Spaces in the name field break direct skill imports in Claude